### PR TITLE
docs: Use stricter OIDC trust policy with branch restriction

### DIFF
--- a/.github/workflows/AWS_OIDC_SETUP.md
+++ b/.github/workflows/AWS_OIDC_SETUP.md
@@ -88,7 +88,8 @@ AWS credentials in GitHub Secrets because:
 ### 3. Update the Role Trust Policy
 
 Edit the trust policy of the role you just created to restrict access to
-your specific repository:
+your specific repository and `main` branch only (following the principle of
+least privilege):
 
 ```json
 {
@@ -102,10 +103,8 @@ your specific repository:
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:YOUR_GITHUB_ORG/packer-aws-windows-openssh:*"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:YOUR_GITHUB_ORG/packer-aws-windows-openssh:ref:refs/heads/main"
         }
       }
     }
@@ -117,6 +116,12 @@ Replace:
 
 - `YOUR_ACCOUNT_ID` with your AWS account ID
 - `YOUR_GITHUB_ORG` with your GitHub organization or username
+
+**Note**: This trust policy uses `StringEquals` for the `sub` condition to
+restrict credentials to the `main` branch only. This prevents pull requests,
+feature branches, and forked repositories from assuming the role, improving
+security. For additional protection, GitHub Actions will skip the
+`build-and-test` workflow for Dependabot PRs which lack secret access.
 
 ### 4. Add the Role ARN to GitHub Secrets
 


### PR DESCRIPTION
## Problem
The current OIDC trust policy documentation uses `StringLike` with a wildcard pattern that allows any environment:
- All pull requests (including Dependabot)
- All branches
- Any future repository conditions

This violates the principle of least privilege.

## Solution
Updated the trust policy to use `StringEquals` with specific branch restriction (`main` only):

**Before:**
```json
"Condition": {
  "StringEquals": {
    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
  },
  "StringLike": {
    "token.actions.githubusercontent.com:sub": "repo:YOUR_GITHUB_ORG/packer-aws-windows-openssh:*"
  }
}
```

**After:**
```json
"Condition": {
  "StringEquals": {
    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
    "token.actions.githubusercontent.com:sub": "repo:YOUR_GITHUB_ORG/packer-aws-windows-openssh:ref:refs/heads/main"
  }
}
```

This approach:
- Aligns with AWS security best practices and the official configure-aws-credentials README
- Prevents pull requests and feature branches from assuming the role
- Complements the Dependabot workflow skip added in PR #32
- Reduces attack surface and improves overall security posture