### PR TITLE
ci: only run build-and-test-ami on relevant file changes

### DIFF
--- a/.github/workflows/build-and-test-ami.yml
+++ b/.github/workflows/build-and-test-ami.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'aws-windows-ssh.pkr.hcl'
+      - 'files/**'
+      - '.github/workflows/build-and-test-ami.yml'
 
 env:
   PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This repository builds an AWS Windows AMI with OpenSSH pre-installed, using Pack
     - Automatically cleans up all test resources (instances, security groups, SSH keys, AMIs, snapshots)
     - Uses AWS OIDC authentication (no static credentials required)
     - **Note**: Dependabot PRs are skipped (job condition: `if: github.actor != 'dependabot[bot]'`) because they lack access to AWS credentials by default. This is expected behavior for security reasons.
+    - **Path filtering**: Only triggers on changes to `aws-windows-ssh.pkr.hcl`, `files/**`, or `.github/workflows/build-and-test-ami.yml`. PRs that only modify docs, tests, or other workflows do not trigger this expensive workflow.
   - [`PSScriptAnalyzer.yml`](./.github/workflows/PSScriptAnalyzer.yml): Lints PowerShell scripts on pull requests
   - [`markdownlint.yml`](./.github/workflows/markdownlint.yml): Lints Markdown files on pull requests
 


### PR DESCRIPTION
Adds `paths` filtering to the `build-and-test-ami` workflow so it only triggers on PRs that modify the Packer template, provisioning scripts, or the workflow file itself. Changes to docs, tests, or other workflows will no longer kick off the expensive AMI build and EC2 test job.

**Paths that trigger the workflow:**
- `aws-windows-ssh.pkr.hcl`
- `files/**`
- `.github/workflows/build-and-test-ami.yml`