### PR TITLE
ci: only run linters on relevant file changes

### DIFF
--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -2,6 +2,9 @@ name: Run PSPSScriptAnalyzer on PowerShell Scripts
 
 on:
   pull_request:
+    paths:
+      - 'files/**'
+      - '.github/workflows/PSScriptAnalyzer.yml'
 
 jobs:
   PSScriptAnalyzer:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,6 +2,9 @@ name: Lint Markdown Files
 
 on:
   pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdownlint.yml'
 
 jobs:
   markdownlint:


### PR DESCRIPTION
Adds `paths` filtering to the `markdownlint` and `PSScriptAnalyzer` workflows, matching the pattern already used in `test.yml`.

**markdownlint** triggers on:
- `**/*.md`
- `.github/workflows/markdownlint.yml`

**PSScriptAnalyzer** triggers on:
- `files/**`
- `.github/workflows/PSScriptAnalyzer.yml`