### PR TITLE
chore: add explicit permissions to workflows

### DIFF
--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -6,6 +6,9 @@ on:
       - 'files/**'
       - '.github/workflows/PSScriptAnalyzer.yml'
 
+permissions:
+  contents: read
+
 jobs:
   PSScriptAnalyzer:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test-ami.yml
+++ b/.github/workflows/build-and-test-ami.yml
@@ -16,7 +16,6 @@ env:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write
 
 jobs:
   build-and-test:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -6,6 +6,9 @@ on:
       - '**/*.md'
       - '.github/workflows/markdownlint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
       - 'files/**'
       - 'tests/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest


### PR DESCRIPTION
Resolves two zizmor audit findings related to GitHub Actions permissions:

**'default permissions used due to no permissions: block'**
Add explicit `permissions: { contents: read }` to workflows that were relying on default token permissions:
- `test.yml`
- `PSScriptAnalyzer.yml`
- `markdownlint.yml`

**Over-permissioned workflow**
Remove unnecessary `pull-requests: write` from `build-and-test-ami.yml`. No step in the workflow comments on, labels, or modifies PRs. Minimum required permissions for that workflow are `id-token: write` (AWS OIDC) and `contents: read` (checkout).