### PR TITLE
refactor(ci): use GITHUB_ENV instead of per-step env aliases

### DIFF
--- a/.github/workflows/build-and-test-ami.yml
+++ b/.github/workflows/build-and-test-ami.yml
@@ -43,35 +43,26 @@ jobs:
         run: packer validate ./aws-windows-ssh.pkr.hcl
 
       - name: Build AMI with Packer
-        id: build
         run: |
-          # Build AMI
           packer build -var "enable_fast_launch=false" ./aws-windows-ssh.pkr.hcl
-          
-          # Extract AMI ID from manifest file
           AMI_ID=$(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d: -f2)
-          echo "ami_id=${AMI_ID}" >> $GITHUB_OUTPUT
+          echo "AMI_ID=${AMI_ID}" >> $GITHUB_ENV
 
       - name: Generate SSH Key Pair
-        id: ssh-key
         run: |
-          # Generate temporary SSH key pair for testing
           ssh-keygen -t rsa -b 4096 -f test-key -N "" -C "github-actions-test"
-          echo "public_key=$(cat test-key.pub)" >> $GITHUB_OUTPUT
           chmod 600 test-key
 
       - name: Import SSH Public Key to AWS
-        id: import-key
         run: |
           KEY_NAME="github-actions-test-$(date +%s)"
           aws ec2 import-key-pair \
             --key-name "${KEY_NAME}" \
             --public-key-material fileb://test-key.pub \
             --region ${{ env.AWS_REGION }}
-          echo "key_name=${KEY_NAME}" >> $GITHUB_OUTPUT
+          echo "KEY_NAME=${KEY_NAME}" >> $GITHUB_ENV
 
       - name: Get Default VPC and Subnet
-        id: vpc-info
         run: |
           VPC_ID=$(aws ec2 describe-vpcs \
             --filters "Name=isDefault,Values=true" \
@@ -87,22 +78,20 @@ jobs:
             --output text \
             --region ${{ env.AWS_REGION }})
           
-          echo "vpc_id=${VPC_ID}" >> $GITHUB_OUTPUT
-          echo "subnet_id=${SUBNET_ID}" >> $GITHUB_OUTPUT
+          echo "VPC_ID=${VPC_ID}" >> $GITHUB_ENV
+          echo "SUBNET_ID=${SUBNET_ID}" >> $GITHUB_ENV
 
       - name: Create Security Group
-        id: security-group
         run: |
           SG_NAME="github-actions-test-$(date +%s)"
           SG_ID=$(aws ec2 create-security-group \
             --group-name "${SG_NAME}" \
             --description "Temporary security group for AMI testing" \
-            --vpc-id "${{ steps.vpc-info.outputs.vpc_id }}" \
+            --vpc-id "${VPC_ID}" \
             --query "GroupId" \
             --output text \
             --region ${{ env.AWS_REGION }})
           
-          # Allow SSH from GitHub Actions
           aws ec2 authorize-security-group-ingress \
             --group-id "${SG_ID}" \
             --protocol tcp \
@@ -110,54 +99,52 @@ jobs:
             --cidr 0.0.0.0/0 \
             --region ${{ env.AWS_REGION }}
           
-          echo "security_group_id=${SG_ID}" >> $GITHUB_OUTPUT
+          echo "SECURITY_GROUP_ID=${SG_ID}" >> $GITHUB_ENV
 
       - name: Launch Test Instance
-        id: launch-instance
         run: |
           INSTANCE_ID=$(aws ec2 run-instances \
-            --image-id "${{ steps.build.outputs.ami_id }}" \
+            --image-id "${AMI_ID}" \
             --instance-type t3a.xlarge \
-            --key-name "${{ steps.import-key.outputs.key_name }}" \
-            --security-group-ids "${{ steps.security-group.outputs.security_group_id }}" \
-            --subnet-id "${{ steps.vpc-info.outputs.subnet_id }}" \
+            --key-name "${KEY_NAME}" \
+            --security-group-ids "${SECURITY_GROUP_ID}" \
+            --subnet-id "${SUBNET_ID}" \
             --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpEndpoint=enabled" \
             --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=github-actions-ami-test},{Key=ManagedBy,Value=github-actions}]" \
             --query "Instances[0].InstanceId" \
             --output text \
             --region ${{ env.AWS_REGION }})
           
-          echo "instance_id=${INSTANCE_ID}" >> $GITHUB_OUTPUT
+          echo "INSTANCE_ID=${INSTANCE_ID}" >> $GITHUB_ENV
           echo "Launched instance: ${INSTANCE_ID}"
 
       - name: Wait for Instance to be Running
         run: |
           echo "Waiting for instance to be in running state..."
           aws ec2 wait instance-running \
-            --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+            --instance-ids "${INSTANCE_ID}" \
             --region ${{ env.AWS_REGION }}
 
       - name: Get Instance Public IP
-        id: instance-ip
         run: |
           PUBLIC_IP=$(aws ec2 describe-instances \
-            --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+            --instance-ids "${INSTANCE_ID}" \
             --query "Reservations[0].Instances[0].PublicIpAddress" \
             --output text \
             --region ${{ env.AWS_REGION }})
           
-          echo "public_ip=${PUBLIC_IP}" >> $GITHUB_OUTPUT
+          echo "PUBLIC_IP=${PUBLIC_IP}" >> $GITHUB_ENV
           echo "Instance IP: ${PUBLIC_IP}"
 
       - name: Test SSH Connection
         run: |
-          echo "Testing SSH connection to ${{ steps.instance-ip.outputs.public_ip }}"
+          echo "Testing SSH connection to ${PUBLIC_IP}"
           
           # Configure SSH to skip host key checking for this test
           mkdir -p ~/.ssh
           cat >> ~/.ssh/config <<EOF
           Host test-instance
-            HostName ${{ steps.instance-ip.outputs.public_ip }}
+            HostName ${PUBLIC_IP}
             User Administrator
             IdentityFile $(pwd)/test-key
             StrictHostKeyChecking no
@@ -239,35 +226,35 @@ jobs:
       - name: Cleanup - Terminate Instance
         if: always()
         run: |
-          if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
-            echo "Terminating instance ${{ steps.launch-instance.outputs.instance_id }}..."
+          if [ -n "${INSTANCE_ID}" ]; then
+            echo "Terminating instance ${INSTANCE_ID}..."
             aws ec2 terminate-instances \
-              --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+              --instance-ids "${INSTANCE_ID}" \
               --region ${{ env.AWS_REGION }} || true
             
             echo "Waiting for instance to terminate..."
             aws ec2 wait instance-terminated \
-              --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+              --instance-ids "${INSTANCE_ID}" \
               --region ${{ env.AWS_REGION }} || true
           fi
 
       - name: Cleanup - Delete Security Group
         if: always()
         run: |
-          if [ -n "${{ steps.security-group.outputs.security_group_id }}" ]; then
-            echo "Deleting security group ${{ steps.security-group.outputs.security_group_id }}..."
+          if [ -n "${SECURITY_GROUP_ID}" ]; then
+            echo "Deleting security group ${SECURITY_GROUP_ID}..."
             aws ec2 delete-security-group \
-              --group-id "${{ steps.security-group.outputs.security_group_id }}" \
+              --group-id "${SECURITY_GROUP_ID}" \
               --region ${{ env.AWS_REGION }} || true
           fi
 
       - name: Cleanup - Delete SSH Key
         if: always()
         run: |
-          if [ -n "${{ steps.import-key.outputs.key_name }}" ]; then
-            echo "Deleting SSH key pair ${{ steps.import-key.outputs.key_name }}..."
+          if [ -n "${KEY_NAME}" ]; then
+            echo "Deleting SSH key pair ${KEY_NAME}..."
             aws ec2 delete-key-pair \
-              --key-name "${{ steps.import-key.outputs.key_name }}" \
+              --key-name "${KEY_NAME}" \
               --region ${{ env.AWS_REGION }} || true
           fi
           
@@ -277,19 +264,19 @@ jobs:
       - name: Cleanup - Deregister AMI
         if: always()
         run: |
-          if [ -n "${{ steps.build.outputs.ami_id }}" ]; then
-            echo "Deregistering AMI ${{ steps.build.outputs.ami_id }}..."
+          if [ -n "${AMI_ID}" ]; then
+            echo "Deregistering AMI ${AMI_ID}..."
             
             # Get snapshot IDs before deregistering
             SNAPSHOT_IDS=$(aws ec2 describe-images \
-              --image-ids "${{ steps.build.outputs.ami_id }}" \
+              --image-ids "${AMI_ID}" \
               --query "Images[0].BlockDeviceMappings[*].Ebs.SnapshotId" \
               --output text \
               --region ${{ env.AWS_REGION }})
             
             # Deregister AMI
             aws ec2 deregister-image \
-              --image-id "${{ steps.build.outputs.ami_id }}" \
+              --image-id "${AMI_ID}" \
               --region ${{ env.AWS_REGION }} || true
             
             # Delete snapshots


### PR DESCRIPTION
Replaces the per-step `env:` aliasing pattern (added to fix zizmor's `template-injection` rule) with job-scoped environment variables written to `$GITHUB_ENV`.

**Problem:** The `template-injection` fix required declaring a verbose `env:` block on every step that consumed a prior step's output. Values reused across multiple steps (e.g. `INSTANCE_ID` across 3 cleanup steps) had to be redeclared each time — 12 env entries in total.

**Solution:** Write values to `$GITHUB_ENV` once in the producing step. They become regular shell variables in every subsequent step automatically — no `${{ }}` interpolation, no per-step aliasing, no template injection.

Net result: 30 lines added, 43 removed. Workflow behaviour is unchanged.