### PR TITLE
fix(ci): add dependabot cooldown to resolve zizmor medium findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -24,3 +26,5 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds `cooldown: default-days: 7` to both Dependabot package ecosystems (`github-actions` and `pre-commit`) to resolve the two medium-severity `dependabot-cooldown` findings reported by zizmor.