### PR TITLE
perf(ci): optimize all workflows with concurrency, caching, faster AMI test, and cancel-safe cleanup

### DIFF
--- a/.github/workflows/AWS_OIDC_SETUP.md
+++ b/.github/workflows/AWS_OIDC_SETUP.md
@@ -45,6 +45,7 @@ AWS credentials in GitHub Secrets because:
         "ec2:TerminateInstances",
         "ec2:CreateFleet",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
         "ec2:DescribeInstanceTypeOfferings",
         "ec2:DescribeImages",
         "ec2:CreateImage",

--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   PSScriptAnalyzer:
     runs-on: ubuntu-latest
@@ -17,6 +21,19 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Cache PowerShell modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.local/share/powershell/Modules
+          key: ${{ runner.os }}-psmodules-pssa-1.24.0
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object Version -eq '1.24.0')) {
+            Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.24.0 -Force -Scope CurrentUser
+          }
 
       - name: Run PSScriptAnalyzer on PowerShell Scripts
         shell: pwsh

--- a/.github/workflows/build-and-test-ami.yml
+++ b/.github/workflows/build-and-test-ami.yml
@@ -17,6 +17,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -36,6 +40,14 @@ jobs:
       - name: Setup Packer
         uses: hashicorp/setup-packer@c3d53c525d422944e50ee27b840746d6522b08de # v3.2.0
 
+      - name: Cache Packer plugins
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.config/packer/plugins
+          key: ${{ runner.os }}-packer-${{ hashFiles('aws-windows-ssh.pkr.hcl') }}
+          restore-keys: |
+            ${{ runner.os }}-packer-
+
       - name: Initialize Packer
         run: packer init ./aws-windows-ssh.pkr.hcl
 
@@ -43,6 +55,8 @@ jobs:
         run: packer validate ./aws-windows-ssh.pkr.hcl
 
       - name: Build AMI with Packer
+        env:
+          PKR_VAR_workflow_run_id: ${{ github.run_id }}
         run: |
           packer build -var "enable_fast_launch=false" ./aws-windows-ssh.pkr.hcl
           AMI_ID=$(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d: -f2)
@@ -56,9 +70,15 @@ jobs:
       - name: Import SSH Public Key to AWS
         run: |
           KEY_NAME="github-actions-test-$(date +%s)"
-          aws ec2 import-key-pair \
+          KEY_PAIR_ID=$(aws ec2 import-key-pair \
             --key-name "${KEY_NAME}" \
             --public-key-material fileb://test-key.pub \
+            --query "KeyPairId" \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+          aws ec2 create-tags \
+            --resources "${KEY_PAIR_ID}" \
+            --tags "Key=WorkflowRunId,Value=${{ github.run_id }}" \
             --region ${{ env.AWS_REGION }}
           echo "KEY_NAME=${KEY_NAME}" >> "$GITHUB_ENV"
 
@@ -99,6 +119,11 @@ jobs:
             --cidr 0.0.0.0/0 \
             --region ${{ env.AWS_REGION }}
 
+          aws ec2 create-tags \
+            --resources "${SG_ID}" \
+            --tags "Key=WorkflowRunId,Value=${{ github.run_id }}" \
+            --region ${{ env.AWS_REGION }}
+
           echo "SECURITY_GROUP_ID=${SG_ID}" >> "$GITHUB_ENV"
 
       - name: Launch Test Instance
@@ -110,7 +135,7 @@ jobs:
             --security-group-ids "${SECURITY_GROUP_ID}" \
             --subnet-id "${SUBNET_ID}" \
             --metadata-options "HttpTokens=required,HttpPutResponseHopLimit=1,HttpEndpoint=enabled" \
-            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=github-actions-ami-test},{Key=ManagedBy,Value=github-actions}]" \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=github-actions-ami-test},{Key=ManagedBy,Value=github-actions},{Key=WorkflowRunId,Value=${{ github.run_id }}}]" \
             --query "Instances[0].InstanceId" \
             --output text \
             --region ${{ env.AWS_REGION }})
@@ -122,6 +147,13 @@ jobs:
         run: |
           echo "Waiting for instance to be in running state..."
           aws ec2 wait instance-running \
+            --instance-ids "${INSTANCE_ID}" \
+            --region ${{ env.AWS_REGION }}
+
+      - name: Wait for Instance Status OK
+        run: |
+          echo "Waiting for instance status checks to pass..."
+          aws ec2 wait instance-status-ok \
             --instance-ids "${INSTANCE_ID}" \
             --region ${{ env.AWS_REGION }}
 
@@ -285,3 +317,74 @@ jobs:
                 --region ${{ env.AWS_REGION }} || true
             done
           fi
+
+      - name: Cleanup - Orphan Sweep
+        if: always()
+        run: |
+          RUN_ID="${{ github.run_id }}"
+          REGION="${{ env.AWS_REGION }}"
+
+          # Terminate any instances tagged with this run (covers Packer build instance
+          # + our test instance if the env-var-guarded step above was skipped)
+          INSTANCES=$(aws ec2 describe-instances \
+            --filters "Name=tag:WorkflowRunId,Values=${RUN_ID}" \
+                      "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+            --query "Reservations[].Instances[].InstanceId" \
+            --output text --region "$REGION")
+          if [ -n "$INSTANCES" ]; then
+            echo "Orphan sweep: terminating instances ${INSTANCES}..."
+            # shellcheck disable=SC2086
+            aws ec2 terminate-instances --instance-ids $INSTANCES --region "$REGION" || true
+            # shellcheck disable=SC2086
+            aws ec2 wait instance-terminated --instance-ids $INSTANCES --region "$REGION" || true
+          fi
+
+          # Deregister any AMIs tagged with this run and delete their snapshots
+          AMIS=$(aws ec2 describe-images --owners self \
+            --filters "Name=tag:WorkflowRunId,Values=${RUN_ID}" \
+            --query "Images[].ImageId" --output text --region "$REGION")
+          for ami in $AMIS; do
+            echo "Orphan sweep: deregistering AMI ${ami}..."
+            SNAPS=$(aws ec2 describe-images --image-ids "$ami" \
+              --query "Images[0].BlockDeviceMappings[*].Ebs.SnapshotId" \
+              --output text --region "$REGION")
+            aws ec2 deregister-image --image-id "$ami" --region "$REGION" || true
+            for snap in $SNAPS; do
+              aws ec2 delete-snapshot --snapshot-id "$snap" --region "$REGION" || true
+            done
+          done
+
+          # Delete tagged security groups and key pairs
+          SGS=$(aws ec2 describe-security-groups \
+            --filters "Name=tag:WorkflowRunId,Values=${RUN_ID}" \
+            --query "SecurityGroups[].GroupId" --output text --region "$REGION")
+          for sg in $SGS; do
+            echo "Orphan sweep: deleting security group ${sg}..."
+            aws ec2 delete-security-group --group-id "$sg" --region "$REGION" || true
+          done
+
+          KPS=$(aws ec2 describe-key-pairs \
+            --filters "Name=tag:WorkflowRunId,Values=${RUN_ID}" \
+            --query "KeyPairs[].KeyName" --output text --region "$REGION")
+          for kp in $KPS; do
+            echo "Orphan sweep: deleting key pair ${kp}..."
+            aws ec2 delete-key-pair --key-name "$kp" --region "$REGION" || true
+          done
+
+          # Best-effort cleanup of Packer's internal packer_* temp resources.
+          # delete-security-group fails harmlessly if the SG is still attached to
+          # a running instance; deleting a keypair from EC2 does not affect
+          # already-launched instances.
+          PACKER_SGS=$(aws ec2 describe-security-groups \
+            --filters "Name=group-name,Values=packer_*" \
+            --query "SecurityGroups[].GroupId" --output text --region "$REGION")
+          for sg in $PACKER_SGS; do
+            aws ec2 delete-security-group --group-id "$sg" --region "$REGION" 2>/dev/null || true
+          done
+
+          PACKER_KPS=$(aws ec2 describe-key-pairs \
+            --filters "Name=key-name,Values=packer_*" \
+            --query "KeyPairs[].KeyName" --output text --region "$REGION")
+          for kp in $PACKER_KPS; do
+            aws ec2 delete-key-pair --key-name "$kp" --region "$REGION" 2>/dev/null || true
+          done

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ on:
 
 permissions:
   contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -25,10 +30,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache PowerShell modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~\Documents\PowerShell\Modules
+          key: ${{ runner.os }}-psmodules-pester-5
+
       - name: Install Pester
         shell: pwsh
         run: |
-          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { [version]$_.Version -ge [version]'5.0' })) {
+            Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
 
       - name: Run Tests
         shell: pwsh
@@ -36,6 +49,9 @@ jobs:
           $config = New-PesterConfiguration
           $config.Run.Path = './tests'
           $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = 'testResults.xml'
+          $config.TestResult.OutputFormat = 'JUnitXml'
 
           $results = Invoke-Pester -Configuration $config
 
@@ -48,4 +64,12 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pester-results
-          path: ./tests/
+          path: testResults.xml
+
+      - name: Publish Test Results
+        if: always()
+        uses: dorny/test-reporter@a6ddd83ac95ff4586f5d3aceeb314d9a1841db95 # v3.0.0
+        with:
+          name: Pester Tests
+          path: testResults.xml
+          reporter: java-junit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository builds an AWS Windows AMI with OpenSSH pre-installed, using Pack
   - IMDSv2 enforcement via `metadata_options` block (`http_tokens = "required"`)
   - 100GB gp3 root volume (vs 30GB default) via `launch_block_device_mappings` for adequate disk space and performance
   - Fast Launch configurable via `enable_fast_launch` variable (default: enabled)
+  - `workflow_run_id` variable (passed as `PKR_VAR_workflow_run_id` from CI) applied via `run_tags`, `run_volume_tags`, `spot_tags`, `tags`, and `snapshot_tags` to enable tag-based orphan cleanup on workflow cancellation
   - Manifest post-processor that outputs AMI IDs to `packer-manifest.json` for CI/CD automation
 
 - **Provisioning Scripts**: All provisioning logic is in [`files/`](./files/):
@@ -20,16 +21,17 @@ This repository builds an AWS Windows AMI with OpenSSH pre-installed, using Pack
 
 - **CI/CD**: GitHub Actions workflows in [`.github/workflows/`](./.github/workflows/):
   - [`build-and-test-ami.yml`](./.github/workflows/build-and-test-ami.yml): Comprehensive end-to-end testing on pull requests:
-    - Validates and builds AMIs using Packer
-    - Launches test instances from the built AMI
+    - Validates and builds AMIs using Packer (plugins cached keyed on template hash)
+    - All Packer and workflow-created AWS resources are tagged `WorkflowRunId=${{ github.run_id }}` to enable safe cancellation
+    - Launches test instances from the built AMI; waits for `instance-status-ok` (OS health checks) before attempting SSH, reducing retry flakiness
     - Tests SSH connectivity with automatic retry logic (20 attempts, 30-second intervals)
     - **Validates IMDSv2 enforcement**: Verifies that IMDSv1 is blocked and IMDSv2 works correctly
-    - Automatically cleans up all test resources (instances, security groups, SSH keys, AMIs, snapshots)
+    - Automatically cleans up all test resources via granular `if: always()` steps plus a final **Orphan Sweep** step that queries by `WorkflowRunId` tag, ensuring cleanup even on mid-build cancellation
     - Uses AWS OIDC authentication (no static credentials required)
     - **Note**: Dependabot PRs are skipped (job condition: `if: github.actor != 'dependabot[bot]'`) because they lack access to AWS credentials by default. This is expected behavior for security reasons.
     - **Path filtering**: Only triggers on changes to `aws-windows-ssh.pkr.hcl`, `files/**`, or `.github/workflows/build-and-test-ami.yml`. PRs that only modify docs, tests, or other workflows do not trigger this expensive workflow.
-  - [`test.yml`](./.github/workflows/test.yml): Runs Pester unit tests for PowerShell scripts on `windows-latest`. Triggers on PRs that change `files/**`, `tests/**`, or the workflow file, and also on pushes to `main` that change `files/**` or `tests/**`.
-  - [`PSScriptAnalyzer.yml`](./.github/workflows/PSScriptAnalyzer.yml): Lints PowerShell scripts on pull requests that change `files/**` or the workflow file itself.
+  - [`test.yml`](./.github/workflows/test.yml): Runs Pester unit tests for PowerShell scripts on `windows-latest`. Pester module is cached; install is skipped on cache hit to avoid PSGallery dependency. Emits JUnit XML and publishes a **Pester Tests** GitHub Check via `dorny/test-reporter`. Triggers on PRs that change `files/**`, `tests/**`, or the workflow file, and also on pushes to `main` that change `files/**` or `tests/**`.
+  - [`PSScriptAnalyzer.yml`](./.github/workflows/PSScriptAnalyzer.yml): Lints PowerShell scripts on pull requests that change `files/**` or the workflow file itself. PSScriptAnalyzer 1.24.0 is pinned and cached; install is skipped on cache hit.
   - [`markdownlint.yml`](./.github/workflows/markdownlint.yml): Lints Markdown files on pull requests that change `**/*.md` or the workflow file itself.
 
 ## Developer Workflows
@@ -64,13 +66,14 @@ This repository builds an AWS Windows AMI with OpenSSH pre-installed, using Pack
     - **Important**: The OIDC trust policy must restrict access to your specific repository using `repo:ORG/REPO:*` pattern to prevent unauthorized access from forks and other repositories.
   - Set up `AWS_ROLE_ARN` secret in GitHub repository settings
   - On pull requests to `main`, workflows will automatically:
-    - Run Pester unit tests for PowerShell scripts
-    - Validate and build AMIs with Packer
+    - Run Pester unit tests for PowerShell scripts (JUnit XML results uploaded as `pester-results` artifact; results also published as a GitHub Check)
+    - Validate and build AMIs with Packer (plugins cached between runs)
     - Launch test instances and verify SSH connectivity
     - Test IMDSv2 enforcement (block IMDSv1, verify IMDSv2 works)
-    - Lint PowerShell scripts with PSScriptAnalyzer
+    - Lint PowerShell scripts with PSScriptAnalyzer (PSScriptAnalyzer module cached)
     - Lint Markdown files with markdownlint
     - Clean up all test resources
+  - **Concurrency**: All workflows use `cancel-in-progress: true` to cancel superseded runs on rapid PR pushes. The AMI build workflow uses a tag-based orphan sweep (`WorkflowRunId=${{ github.run_id }}`) stamped on every Packer and workflow-created resource, with a final `Cleanup - Orphan Sweep` step (`if: always()`) that terminates/deregisters/deletes by that tag so mid-build cancellation leaves no leaked AWS resources.
 
 ## Project Conventions
 

--- a/aws-windows-ssh.pkr.hcl
+++ b/aws-windows-ssh.pkr.hcl
@@ -22,6 +22,11 @@ variable "enable_fast_launch" {
   default = true
 }
 
+variable "workflow_run_id" {
+  type    = string
+  default = ""
+}
+
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 data "amazon-ami" "aws-windows-ssh" {
@@ -65,14 +70,29 @@ source "amazon-ebs" "aws-windows-ssh" {
   fast_launch {
     enable_fast_launch = var.enable_fast_launch
   }
+  run_tags = {
+    Name          = "packer-build-${var.ami_name_prefix}"
+    WorkflowRunId = var.workflow_run_id
+  }
+
+  run_volume_tags = {
+    WorkflowRunId = var.workflow_run_id
+  }
+
+  spot_tags = {
+    WorkflowRunId = var.workflow_run_id
+  }
+
   snapshot_tags = {
-    Name      = "${var.image_name}"
-    BuildTime = "${local.timestamp}"
+    Name          = "${var.image_name}"
+    BuildTime     = "${local.timestamp}"
+    WorkflowRunId = var.workflow_run_id
   }
 
   tags = {
-    Name      = "${var.image_name}"
-    BuildTime = "${local.timestamp}"
+    Name          = "${var.image_name}"
+    BuildTime     = "${local.timestamp}"
+    WorkflowRunId = var.workflow_run_id
   }
 }
 


### PR DESCRIPTION
## Summary

Optimizes all four CI/CD workflows for faster feedback, lower resource waste, and safe mid-build cancellation.

## Changes by workflow

### `build-and-test-ami.yml`
- **Concurrency** (`cancel-in-progress: true`): superseded runs are cancelled immediately for faster PR feedback
- **Packer plugin cache**: caches `~/.config/packer/plugins` keyed on template hash
- **`workflow_run_id` tagging**: new Packer variable `workflow_run_id` (passed via `PKR_VAR_workflow_run_id` env) stamps `WorkflowRunId=${{ github.run_id }}` on all Packer-managed resources (`run_tags`, `run_volume_tags`, `spot_tags`, `tags`, `snapshot_tags`). Workflow-created resources (imported keypair, security group, test instance) are also tagged.
- **Wait for Instance Status OK**: new step after `instance-running` waits for EC2 OS-level health checks before SSH, expected to cut retry loop from ~5-10 attempts to ~1-2
- **Orphan Sweep** (`if: always()`): final step queries by `WorkflowRunId` tag to terminate instances, deregister AMIs/snapshots, delete SGs and key pairs — works even on mid-build cancellation. Also best-effort cleans Packer's internal `packer_*` named temp resources.

### `test.yml`
- **Concurrency** (`cancel-in-progress: true`)
- **Pester module cache**: caches `~\\Documents\\PowerShell\\Modules` keyed by major version; install skipped on cache hit to avoid PSGallery dependency
- **JUnit XML + GitHub Check**: emits `testResults.xml` in JUnit format and publishes a **Pester Tests** Check via `dorny/test-reporter` with `checks: write` permission

### `PSScriptAnalyzer.yml`
- **Concurrency** (`cancel-in-progress: true`)
- **Pin + cache PSScriptAnalyzer 1.24.0**: explicit version for reproducibility; cached in the CurrentUser modules dir; install skipped on cache hit

### `markdownlint.yml`
- **Concurrency** (`cancel-in-progress: true`)

### `aws-windows-ssh.pkr.hcl`
- New `workflow_run_id` variable for tag-based orphan tracking
- Added `run_tags`, `run_volume_tags`, `spot_tags` blocks; added `WorkflowRunId` to existing `tags` and `snapshot_tags`

### `.github/workflows/AWS_OIDC_SETUP.md`
- Added `ec2:DescribeInstanceStatus` to the IAM policy for the `instance-status-ok` wait step