### PR TITLE
chore(dependabot): update schedules from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:30"
       timezone: "America/Toronto"
     pull-request-branch-name:
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:45"
       timezone: "America/Toronto"
     pull-request-branch-name:


### PR DESCRIPTION
Changes dependabot update schedules from weekly to daily for both github-actions and pre-commit packages, enabling more frequent dependency updates.