### PR TITLE
fix: allow exit code 2300218 from PrepareImage provisioner

### DIFF
--- a/aws-windows-ssh.pkr.hcl
+++ b/aws-windows-ssh.pkr.hcl
@@ -108,7 +108,8 @@ build {
   }
 
   provisioner "powershell" {
-    script = "files/PrepareImage.ps1"
+    script           = "files/PrepareImage.ps1"
+    valid_exit_codes = [0, 2300218]
   }
 
   post-processor "manifest" {


### PR DESCRIPTION
## Summary

- Adds `valid_exit_codes = [0, 2300218]` to the `PrepareImage.ps1` powershell provisioner
- `2300218` is a Packer internal magic number (defined in `communicator.go`) meaning the SSH connection dropped before the remote command returned an exit code (see [here](https://github.com/hashicorp/packer/blob/2f86cc4001a90dcba82599ee074d62bb6c45acec/provisioner/shell/provisioner.go#L360))
- This is expected behavior: `ec2launch sysprep` initiates Sysprep, Windows shuts down, and the SSH session is killed mid-execution — Packer sees this as exit code `2300218` rather than `0`

## Context

Build started failing with:
```
Script exited with non-zero exit status: 2300218. Allowed exit codes are: [0]
```

This is not an error from `ec2launch.exe` itself — it's Packer's sentinel value for an SSH disconnect without a returned exit code. Relevant upstream issue: https://github.com/hashicorp/packer/issues/4623

## Test plan

- [x] Trigger a build and confirm the `PrepareImage.ps1` provisioner step passes
- [x] Confirm the resulting AMI boots and SSH is functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)